### PR TITLE
Add more to Activity to calculate weekly steps of the last 7 days (+other methods, trends, tests)

### DIFF
--- a/src/Activity.js
+++ b/src/Activity.js
@@ -77,6 +77,61 @@ class Activity {
     });
     return Math.ceil((daysAchieved.length / userData.length) * 100);
   }
+
+  // * Iteration 5 (this is giving you the total steps for the last 7 days)
+  getWeeklySteps(date, idNumber) {
+    let userData = this.getUserActivityData(idNumber);
+    let lastDay;
+    userData.forEach((activity, index) =>
+      activity.date === date ? (lastDay = index) : null
+    );
+    let weekly = userData.slice(lastDay - 6, lastDay + 1);
+    let totalWeeklySteps = weekly.reduce((acc, active) => {
+      acc += active.numSteps;
+      return acc;
+    }, 0);
+    return totalWeeklySteps;
+  }
+
+  // * What days had increasing steps for 3 or more days, for a user.
+  getDaysWithStepsTrend(idNumber) {
+    let userData = this.getUserActivityData(idNumber);
+    let daysTrend = userData.reduce((acc, day, index) => {
+      if (index < 2) {
+        return acc;
+      }
+      console.log(day.numSteps);
+      console.log(userData[index - 1].numSteps);
+      console.log(userData[index - 2].numSteps);
+      if (
+        day.numSteps > userData[index - 1].numSteps &&
+        userData[index - 1].numSteps > userData[index - 2].numSteps
+      ) {
+        acc.push(day.date);
+      }
+      return acc;
+    }, []);
+    return daysTrend;
+  }
+
+  // * Our Own Trend
+  compareMilesWalkedToHike(idNumber, user) {
+    let userData = this.getUserActivityData(idNumber);
+    let totalStepsTaken = userData.reduce((acc, active) => {
+      acc += active.numSteps;
+      return acc;
+    }, 0);
+    console.log(totalStepsTaken);
+    let totalMilesWalked = Number(
+      (totalStepsTaken * user.strideLength) / 5280
+    ).toFixed(1);
+    let mountRainierSummitHike = 14.7;
+    let timesYouHiked = Number(
+      totalMilesWalked / mountRainierSummitHike
+    ).toFixed(1);
+
+    return `Your ${totalMilesWalked} lifetime miles is equivalent to ${timesYouHiked} times you have done Mount Rainier Standard Summit Hike`;
+  }
 }
 
 if (typeof module !== 'undefined') {

--- a/test/activity-test.js
+++ b/test/activity-test.js
@@ -56,7 +56,22 @@ describe('ACTIVITY', () => {
     ).to.equal(25.5);
   });
 
-  it.only('should calculate how often a user achieve their step goal in percentage', () => {
+  it('should calculate how often a user achieve their step goal in percentage', () => {
     expect(activity.calculateStepGoalAchievement(user2)).to.equal(50);
+  });
+
+  it('should give out friends steps', () => {
+    expect(activity.getWeeklySteps('2019/06/21', user2ID)).to.equal(55054);
+  });
+
+  it('should return the dates where user had increased steps for the previous 3 days', () => {
+    let daysTrend = ['2019/06/18', '2019/06/19'];
+    expect(activity.getDaysWithStepsTrend(8)).to.eql(daysTrend);
+  });
+
+  it('should return lifetime miles and calculate how many times the hikes were completed based on lifetime miles', () => {
+    expect(activity.compareMilesWalkedToHike(user1ID, user1)).to.equal(
+      'Your 56.1 lifetime miles is equivalent to 3.8 times you have done Mount Rainier Standard Summit Hike'
+    );
   });
 });


### PR DESCRIPTION
Total weekly steps to be used for comparing to friends.  Method for days with 3 or more days where step count increased, return date.  Add our own trend where we compare total lifetime miles with a Mount Rainier summit hike.  Add all the tests associated with new methods.